### PR TITLE
Use `fgrep -e` instead of `grep`

### DIFF
--- a/autolock.sh
+++ b/autolock.sh
@@ -1,5 +1,5 @@
 SSID='Death Star'
-HOME=`ioreg -rn en0 | grep "$SSID"`
+HOME=`ioreg -rn en0 | fgrep -e "$SSID"`
 
 if [ "$HOME" ]; then
   SECURE='false'


### PR DESCRIPTION
Eliminates (the very rare) edge cases of `ssid` names in `$HOME` that contain regex meta characters and/or start with `-`.
- an `ssid` that starts with `-` could cause unexpected behavior in `grep`
- an `ssid` that contains regex meta characters could, in _very_ rare cases, cause a false positive match
