### PR TITLE
Change SSID detection to be exact

### DIFF
--- a/autolock.sh
+++ b/autolock.sh
@@ -1,7 +1,7 @@
 HOME_SSID='Death Star'
-CURRENT_SSID=`ioreg -rn en0 | fgrep -e "$HOME_SSID"`
+CURRENT_SSID=`/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk 'BEGIN { FS = ": " }; /[^B]SSID/ { print $2 }'`
 
-if [ "$CURRENT_SSID" ]; then
+if [ "$CURRENT_SSID" = "$HOME_SSID" ]; then
   PASS_ON_WAKE='false'
 else
   PASS_ON_WAKE='true'


### PR DESCRIPTION
SSIDs are now matched exactly instead of partially. For example, if your HOME_SSID is `foo`, before it would match SSIDs such as `food`, `Underfoot`, and `tomfoolery`. Now it must match exactly
